### PR TITLE
DNS Edit Tool with Version Control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,8 +198,25 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "form_urlencoded"
@@ -208,6 +225,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -471,6 +500,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+
+[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,6 +616,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustix"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +719,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +802,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -886,6 +957,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ regex = "1.10.3"
 git2 = "0.18.2"
 chrono = "0.4.34"
 thiserror = "1.0.56"
+
+[dev-dependencies]
+tempfile = "3.10.1"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# DNS Edit
+
+A command-line tool to manage your `/etc/hosts` DNS entries with built-in version control.
+
+## Features
+
+- List, add, remove, and update DNS entries
+- Automatic validation of IP addresses and hostnames
+- Git-based version control with automatic backups
+- Restore previous versions from backup history
+- Simple, intuitive command-line interface
+
+## Installation
+
+```bash
+cargo install dns_edit
+```
+
+Or build from source:
+
+```bash
+git clone https://github.com/yourusername/dns_edit.git
+cd dns_edit
+cargo build --release
+```
+
+## Usage
+
+This tool should be run with sufficient permissions to modify `/etc/hosts` (usually with sudo).
+
+### List all DNS entries
+```bash
+sudo dns_edit list
+# Filter entries
+sudo dns_edit list -f example.com
+```
+
+### Add a new DNS entry
+```bash
+sudo dns_edit add 127.0.0.1 example.local
+```
+
+### Remove a DNS entry
+```bash
+sudo dns_edit remove example.local
+```
+
+### Update an existing DNS entry
+```bash
+sudo dns_edit update example.local 192.168.1.10
+```
+
+### Restore from backup
+```bash
+# Restore from latest backup
+sudo dns_edit restore
+# Restore from specific commit
+sudo dns_edit restore -c abc123
+```
+
+## Backups
+
+All modifications to the hosts file are automatically backed up to `/usr/local/dns` in a git repository. Each operation creates a separate commit, making it easy to track changes and restore previous versions.
+
+## License
+
+MIT License

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,14 @@ use std::process::Command as ProcessCommand;
 use std::str::FromStr;
 use thiserror::Error;
 
-// Constants
-const HOSTS_FILE: &str = "/etc/hosts";
-const BACKUP_DIR: &str = "/usr/local/dns";
+// Constants with environment variable overrides for testing
+fn hosts_file() -> String {
+    std::env::var("HOSTS_FILE").unwrap_or_else(|_| "/etc/hosts".to_string())
+}
+
+fn backup_dir() -> String {
+    std::env::var("BACKUP_DIR").unwrap_or_else(|_| "/usr/local/dns".to_string())
+}
 
 #[derive(Debug, Error)]
 enum DnsEditError {
@@ -178,13 +183,22 @@ impl DnsFile {
         // Basic hostname validation
         // RFC 1123 & 952 rules: letters, digits, hyphens, not starting/ending with hyphen
         // More complex validation with regex is possible
-        let valid_chars = |c: char| c.is_alphanumeric() || c == '-' || c == '.';
         
-        !hostname.is_empty() 
-            && hostname.chars().all(valid_chars)
-            && !hostname.starts_with('-')
-            && !hostname.ends_with('-')
-            && hostname.len() <= 253
+        if hostname.is_empty() || hostname.len() > 253 {
+            return false;
+        }
+        
+        // Check each label between dots
+        for label in hostname.split('.') {
+            if label.is_empty() 
+                || label.starts_with('-') 
+                || label.ends_with('-') 
+                || !label.chars().all(|c| c.is_alphanumeric() || c == '-') {
+                return false;
+            }
+        }
+        
+        true
     }
     
     fn add_entry(&mut self, ip: &str, hostname: &str) -> Result<()> {
@@ -260,16 +274,17 @@ impl DnsFile {
 
 fn init_git_repo() -> Result<()> {
     // Create backup directory if it doesn't exist
-    fs::create_dir_all(BACKUP_DIR)
+    let backup_dir_path = backup_dir();
+    fs::create_dir_all(&backup_dir_path)
         .map_err(|e| DnsEditError::Io(e))?;
     
     // Check if git repository already exists
-    let git_dir = PathBuf::from(BACKUP_DIR).join(".git");
+    let git_dir = PathBuf::from(&backup_dir_path).join(".git");
     if !git_dir.exists() {
         // Initialize git repository
         let output = ProcessCommand::new("git")
             .args(["init"])
-            .current_dir(BACKUP_DIR)
+            .current_dir(&backup_dir_path)
             .output()
             .map_err(|e| DnsEditError::GitError(format!("Failed to initialize git repo: {}", e)))?;
         
@@ -280,12 +295,12 @@ fn init_git_repo() -> Result<()> {
         // Configure git user for commits
         let _ = ProcessCommand::new("git")
             .args(["config", "user.name", "DNS Edit"])
-            .current_dir(BACKUP_DIR)
+            .current_dir(&backup_dir_path)
             .output();
             
         let _ = ProcessCommand::new("git")
             .args(["config", "user.email", "dns-edit@localhost"])
-            .current_dir(BACKUP_DIR)
+            .current_dir(&backup_dir_path)
             .output();
     }
     
@@ -297,24 +312,27 @@ fn backup_hosts_file(message: &str) -> Result<()> {
     init_git_repo()?;
     
     // Copy current hosts file to backup directory
-    let hosts_content = fs::read_to_string(HOSTS_FILE)
+    let hosts_file_path = hosts_file();
+    let backup_dir_path = backup_dir();
+    
+    let hosts_content = fs::read_to_string(&hosts_file_path)
         .map_err(|e| DnsEditError::Io(e))?;
     
-    let backup_path = PathBuf::from(BACKUP_DIR).join("hosts");
+    let backup_path = PathBuf::from(&backup_dir_path).join("hosts");
     fs::write(&backup_path, hosts_content)
         .map_err(|e| DnsEditError::Io(e))?;
     
     // Add to git
     let _ = ProcessCommand::new("git")
         .args(["add", "hosts"])
-        .current_dir(BACKUP_DIR)
+        .current_dir(&backup_dir_path)
         .output()
         .map_err(|e| DnsEditError::GitError(format!("Failed to add to git: {}", e)))?;
     
     // Commit changes
     let output = ProcessCommand::new("git")
         .args(["commit", "-m", message])
-        .current_dir(BACKUP_DIR)
+        .current_dir(&backup_dir_path)
         .output()
         .map_err(|e| DnsEditError::GitError(format!("Failed to commit: {}", e)))?;
     
@@ -334,10 +352,12 @@ fn restore_from_backup(commit: Option<&str>) -> Result<()> {
     
     // Checkout specific commit or HEAD
     let commit_ref = commit.unwrap_or("HEAD");
+    let backup_dir_path = backup_dir();
+    let hosts_file_path = hosts_file();
     
     let output = ProcessCommand::new("git")
         .args(["checkout", commit_ref, "--", "hosts"])
-        .current_dir(BACKUP_DIR)
+        .current_dir(&backup_dir_path)
         .output()
         .map_err(|e| DnsEditError::GitError(format!("Failed to checkout: {}", e)))?;
     
@@ -345,23 +365,217 @@ fn restore_from_backup(commit: Option<&str>) -> Result<()> {
         return Err(DnsEditError::GitError(String::from_utf8_lossy(&output.stderr).to_string()));
     }
     
-    // Copy restored file back to /etc/hosts
-    let backup_path = PathBuf::from(BACKUP_DIR).join("hosts");
+    // Copy restored file back to hosts file
+    let backup_path = PathBuf::from(&backup_dir_path).join("hosts");
     let backup_content = fs::read_to_string(&backup_path)
         .map_err(|e| DnsEditError::Io(e))?;
     
-    fs::write(HOSTS_FILE, backup_content)
+    fs::write(&hosts_file_path, backup_content)
         .map_err(|e| DnsEditError::Io(e))?;
     
     Ok(())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_is_valid_ip() {
+        // Valid IPs
+        assert!(DnsFile::is_valid_ip("127.0.0.1"));
+        assert!(DnsFile::is_valid_ip("192.168.1.1"));
+        assert!(DnsFile::is_valid_ip("::1"));
+        assert!(DnsFile::is_valid_ip("2001:db8::1"));
+        
+        // Invalid IPs
+        assert!(!DnsFile::is_valid_ip("256.0.0.1"));
+        assert!(!DnsFile::is_valid_ip("127.0.0"));
+        assert!(!DnsFile::is_valid_ip("hello"));
+        assert!(!DnsFile::is_valid_ip(""));
+    }
+    
+    #[test]
+    fn test_is_valid_hostname() {
+        // Valid hostnames
+        assert!(DnsFile::is_valid_hostname("localhost"));
+        assert!(DnsFile::is_valid_hostname("example.com"));
+        assert!(DnsFile::is_valid_hostname("sub-domain.example.com"));
+        assert!(DnsFile::is_valid_hostname("test123.local"));
+        
+        // Invalid hostnames
+        assert!(!DnsFile::is_valid_hostname("-invalid.com"));
+        assert!(!DnsFile::is_valid_hostname("invalid-.com"));
+        assert!(!DnsFile::is_valid_hostname("invalid$char.com"));
+        assert!(!DnsFile::is_valid_hostname(""));
+    }
+    
+    #[test]
+    fn test_parse_hosts_file() {
+        let content = "# This is a comment
+127.0.0.1 localhost
+::1 localhost ip6-localhost ip6-loopback
+192.168.1.100 test.local
+";
+        let dns_file = DnsFile::from_content(content).unwrap();
+        
+        assert_eq!(dns_file.comments.len(), 1);
+        assert_eq!(dns_file.comments[0], "# This is a comment");
+        
+        assert_eq!(dns_file.entries.len(), 3);
+        
+        // Check first entry
+        assert_eq!(dns_file.entries[0].ip, "127.0.0.1");
+        assert_eq!(dns_file.entries[0].hostnames.len(), 1);
+        assert_eq!(dns_file.entries[0].hostnames[0], "localhost");
+        
+        // Check second entry
+        assert_eq!(dns_file.entries[1].ip, "::1");
+        assert_eq!(dns_file.entries[1].hostnames.len(), 3);
+        assert_eq!(dns_file.entries[1].hostnames[0], "localhost");
+        assert_eq!(dns_file.entries[1].hostnames[1], "ip6-localhost");
+        assert_eq!(dns_file.entries[1].hostnames[2], "ip6-loopback");
+        
+        // Check third entry
+        assert_eq!(dns_file.entries[2].ip, "192.168.1.100");
+        assert_eq!(dns_file.entries[2].hostnames.len(), 1);
+        assert_eq!(dns_file.entries[2].hostnames[0], "test.local");
+    }
+    
+    #[test]
+    fn test_to_string() {
+        let content = "# Comment line
+127.0.0.1 localhost
+::1 ip6-localhost
+";
+        let dns_file = DnsFile::from_content(content).unwrap();
+        let output = dns_file.to_string();
+        
+        assert!(output.contains("# Comment line"));
+        assert!(output.contains("127.0.0.1 localhost"));
+        assert!(output.contains("::1 ip6-localhost"));
+    }
+    
+    #[test]
+    fn test_add_entry() {
+        let content = "127.0.0.1 localhost
+";
+        let mut dns_file = DnsFile::from_content(content).unwrap();
+        
+        // Add to new IP
+        dns_file.add_entry("192.168.1.10", "test.local").unwrap();
+        
+        assert_eq!(dns_file.entries.len(), 2);
+        assert_eq!(dns_file.entries[1].ip, "192.168.1.10");
+        assert_eq!(dns_file.entries[1].hostnames[0], "test.local");
+        
+        // Add to existing IP
+        dns_file.add_entry("127.0.0.1", "another.local").unwrap();
+        
+        assert_eq!(dns_file.entries.len(), 2);  // Should still be 2 IPs
+        assert_eq!(dns_file.entries[0].hostnames.len(), 2);  // But with 2 hostnames
+        assert_eq!(dns_file.entries[0].hostnames[1], "another.local");
+        
+        // Try to add duplicate (should fail)
+        let result = dns_file.add_entry("1.1.1.1", "localhost");
+        assert!(result.is_err());
+        
+        // Invalid inputs
+        assert!(dns_file.add_entry("999.0.0.1", "test2.local").is_err());
+        assert!(dns_file.add_entry("1.1.1.1", "invalid-.local").is_err());
+    }
+    
+    #[test]
+    fn test_remove_entry() {
+        let content = "127.0.0.1 localhost another.local
+192.168.1.1 test.local
+";
+        let mut dns_file = DnsFile::from_content(content).unwrap();
+        
+        // Remove one of multiple hostnames
+        dns_file.remove_entry("another.local").unwrap();
+        
+        assert_eq!(dns_file.entries.len(), 2);
+        assert_eq!(dns_file.entries[0].hostnames.len(), 1);
+        assert_eq!(dns_file.entries[0].hostnames[0], "localhost");
+        
+        // Remove last hostname for an IP (should remove the entire entry)
+        dns_file.remove_entry("test.local").unwrap();
+        
+        assert_eq!(dns_file.entries.len(), 1);
+        
+        // Try to remove non-existent hostname
+        let result = dns_file.remove_entry("nonexistent.local");
+        assert!(result.is_err());
+    }
+    
+    #[test]
+    fn test_update_entry() {
+        let content = "127.0.0.1 localhost
+192.168.1.1 test.local
+";
+        let mut dns_file = DnsFile::from_content(content).unwrap();
+        
+        // Update an entry
+        dns_file.update_entry("test.local", "10.0.0.1").unwrap();
+        
+        // Original IP should be gone
+        assert_eq!(dns_file.entries.len(), 2);
+        
+        // Find the updated entry
+        let updated_entry = dns_file.entries.iter()
+            .find(|entry| entry.ip == "10.0.0.1")
+            .unwrap();
+            
+        assert_eq!(updated_entry.hostnames.len(), 1);
+        assert_eq!(updated_entry.hostnames[0], "test.local");
+        
+        // Try to update non-existent hostname
+        let result = dns_file.update_entry("nonexistent.local", "1.1.1.1");
+        assert!(result.is_err());
+        
+        // Invalid inputs
+        assert!(dns_file.update_entry("localhost", "999.0.0.1").is_err());
+    }
+    
+    #[test]
+    fn test_corrupt_file_detection() {
+        // Invalid IP
+        let content = "999.0.0.1 localhost
+";
+        assert!(DnsFile::from_content(content).is_err());
+        
+        // Invalid hostname
+        let content = "127.0.0.1 invalid$.com
+";
+        assert!(DnsFile::from_content(content).is_err());
+        
+        // Empty line with whitespace (should be OK)
+        let content = "127.0.0.1 localhost
+  
+192.168.1.1 test.local
+";
+        assert!(DnsFile::from_content(content).is_ok());
+    }
+}
+
 fn main() -> Result<()> {
+    // Set up error handling for the CLI
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn run() -> Result<()> {
     let cli = Cli::parse();
+    
+    let hosts_file_path = hosts_file();
     
     match &cli.command {
         Commands::List { filter } => {
-            let content = fs::read_to_string(HOSTS_FILE)?;
+            let content = fs::read_to_string(&hosts_file_path)?;
             let dns_file = DnsFile::from_content(&content)?;
             
             println!("DNS Entries:");
@@ -382,14 +596,14 @@ fn main() -> Result<()> {
             backup_hosts_file(&format!("Backup before adding {} -> {}", hostname, ip))?;
             
             // Read and parse hosts file
-            let content = fs::read_to_string(HOSTS_FILE)?;
+            let content = fs::read_to_string(&hosts_file_path)?;
             let mut dns_file = DnsFile::from_content(&content)?;
             
             // Add new entry
             dns_file.add_entry(ip, hostname)?;
             
             // Write back to hosts file
-            fs::write(HOSTS_FILE, dns_file.to_string())?;
+            fs::write(&hosts_file_path, dns_file.to_string())?;
             
             println!("Added DNS entry: {} -> {}", hostname, ip);
         }
@@ -399,14 +613,14 @@ fn main() -> Result<()> {
             backup_hosts_file(&format!("Backup before removing {}", hostname))?;
             
             // Read and parse hosts file
-            let content = fs::read_to_string(HOSTS_FILE)?;
+            let content = fs::read_to_string(&hosts_file_path)?;
             let mut dns_file = DnsFile::from_content(&content)?;
             
             // Remove entry
             dns_file.remove_entry(hostname)?;
             
             // Write back to hosts file
-            fs::write(HOSTS_FILE, dns_file.to_string())?;
+            fs::write(&hosts_file_path, dns_file.to_string())?;
             
             println!("Removed DNS entry for {}", hostname);
         }
@@ -416,14 +630,14 @@ fn main() -> Result<()> {
             backup_hosts_file(&format!("Backup before updating {} to {}", hostname, ip))?;
             
             // Read and parse hosts file
-            let content = fs::read_to_string(HOSTS_FILE)?;
+            let content = fs::read_to_string(&hosts_file_path)?;
             let mut dns_file = DnsFile::from_content(&content)?;
             
             // Update entry
             dns_file.update_entry(hostname, ip)?;
             
             // Write back to hosts file
-            fs::write(HOSTS_FILE, dns_file.to_string())?;
+            fs::write(&hosts_file_path, dns_file.to_string())?;
             
             println!("Updated DNS entry: {} -> {}", hostname, ip);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,38 +1,439 @@
-use serde::Serialize;
-use std::collections::HashMap;
+use clap::{Parser, Subcommand};
+use serde::{Deserialize, Serialize};
 use std::fs;
-use std::env;
+use std::io;
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::process::Command as ProcessCommand;
+use std::str::FromStr;
+use thiserror::Error;
 
-fn main() {
-    let file_path = String::from("/etc/hosts");
-    let content = fs::read_to_string(&file_path).expect("Failed to read file");
+// Constants
+const HOSTS_FILE: &str = "/etc/hosts";
+const BACKUP_DIR: &str = "/usr/local/dns";
 
-    let mut dns: HashMap<&str, &str> = HashMap::new();
+#[derive(Debug, Error)]
+enum DnsEditError {
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+    
+    #[error("Failed to parse hosts file: {0}")]
+    ParseError(String),
+    
+    #[error("Git operation failed: {0}")]
+    GitError(String),
+    
+    #[error("Invalid IP address: {0}")]
+    InvalidIp(String),
+    
+    #[error("Invalid hostname: {0}")]
+    InvalidHostname(String),
+    
+    #[error("DNS corruption detected. Aborting edit.")]
+    DnsCorruption,
+}
 
-    for (n, line) in content.lines().enumerate() {
-        if !(line.is_empty() || line.starts_with('#')) {
-            if line.contains(' ') || line.contains('\t') {
-                //println!("line: {line}");
+type Result<T> = std::result::Result<T, DnsEditError>;
+
+#[derive(Parser)]
+#[command(name = "DNS Edit")]
+#[command(author = "DNS Editor")]
+#[command(version = "1.0")]
+#[command(about = "Edit your DNS by updating /etc/hosts programmatically with version control", long_about = None)]
+struct Cli {
+    /// Turn on verbose output
+    #[arg(short, long)]
+    verbose: bool,
+    
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List all DNS entries
+    List {
+        /// Optional filter for hostname pattern
+        #[arg(short, long)]
+        filter: Option<String>,
+    },
+    /// Add a new DNS entry
+    Add {
+        /// IP address (IPv4 or IPv6)
+        #[arg(index = 1)]
+        ip: String,
+        
+        /// Hostname to associate with the IP
+        #[arg(index = 2)]
+        hostname: String,
+    },
+    /// Remove a DNS entry
+    Remove {
+        /// Hostname to remove
+        #[arg(index = 1)]
+        hostname: String,
+    },
+    /// Update an existing DNS entry
+    Update {
+        /// Hostname to update
+        #[arg(index = 1)]
+        hostname: String,
+        
+        /// New IP address
+        #[arg(index = 2)]
+        ip: String,
+    },
+    /// Restore a specific backup
+    Restore {
+        /// Commit hash to restore (defaults to latest)
+        #[arg(short, long)]
+        commit: Option<String>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DnsEntry {
+    ip: String,
+    hostnames: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DnsFile {
+    entries: Vec<DnsEntry>,
+    comments: Vec<String>,
+}
+
+impl DnsFile {
+    fn from_content(content: &str) -> Result<Self> {
+        let mut entries = Vec::new();
+        let mut comments = Vec::new();
+        
+        for line in content.lines() {
+            let line = line.trim();
+            
+            if line.is_empty() {
+                continue;
+            } else if line.starts_with('#') {
+                comments.push(line.to_string());
+            } else if line.contains(' ') || line.contains('\t') {
                 let mut parts = line.split_whitespace();
                 if let Some(ip) = parts.next() {
-                    let names = parts.collect::<Vec<&str>>();
-                    for name in names.iter() {
-                        dns.insert(name, ip);
+                    // Validate IP
+                    if !Self::is_valid_ip(ip) {
+                        return Err(DnsEditError::DnsCorruption);
                     }
+                    
+                    let hostnames: Vec<String> = parts
+                        .map(|name| {
+                            if !Self::is_valid_hostname(name) {
+                                Err(DnsEditError::DnsCorruption)
+                            } else {
+                                Ok(name.to_string())
+                            }
+                        })
+                        .collect::<Result<Vec<String>>>()?;
+                    
+                    entries.push(DnsEntry {
+                        ip: ip.to_string(),
+                        hostnames,
+                    });
+                } else {
+                    return Err(DnsEditError::DnsCorruption);
+                }
+            } else {
+                return Err(DnsEditError::DnsCorruption);
+            }
+        }
+        
+        Ok(DnsFile { entries, comments })
+    }
+    
+    fn to_string(&self) -> String {
+        let mut result = String::new();
+        
+        // Add comments
+        for comment in &self.comments {
+            result.push_str(comment);
+            result.push('\n');
+        }
+        
+        // Add entries
+        for entry in &self.entries {
+            result.push_str(&entry.ip);
+            for hostname in &entry.hostnames {
+                result.push_str(" ");
+                result.push_str(hostname);
+            }
+            result.push('\n');
+        }
+        
+        result
+    }
+    
+    fn is_valid_ip(ip: &str) -> bool {
+        IpAddr::from_str(ip).is_ok()
+    }
+    
+    fn is_valid_hostname(hostname: &str) -> bool {
+        // Basic hostname validation
+        // RFC 1123 & 952 rules: letters, digits, hyphens, not starting/ending with hyphen
+        // More complex validation with regex is possible
+        let valid_chars = |c: char| c.is_alphanumeric() || c == '-' || c == '.';
+        
+        !hostname.is_empty() 
+            && hostname.chars().all(valid_chars)
+            && !hostname.starts_with('-')
+            && !hostname.ends_with('-')
+            && hostname.len() <= 253
+    }
+    
+    fn add_entry(&mut self, ip: &str, hostname: &str) -> Result<()> {
+        // Validate inputs
+        if !Self::is_valid_ip(ip) {
+            return Err(DnsEditError::InvalidIp(ip.to_string()));
+        }
+        
+        if !Self::is_valid_hostname(hostname) {
+            return Err(DnsEditError::InvalidHostname(hostname.to_string()));
+        }
+        
+        // Check if hostname already exists
+        for entry in &mut self.entries {
+            if entry.hostnames.contains(&hostname.to_string()) {
+                return Err(DnsEditError::ParseError(format!("Hostname {} already exists", hostname)));
+            }
+        }
+        
+        // Find if IP already exists
+        for entry in &mut self.entries {
+            if entry.ip == ip {
+                entry.hostnames.push(hostname.to_string());
+                return Ok(());
+            }
+        }
+        
+        // Create new entry
+        self.entries.push(DnsEntry {
+            ip: ip.to_string(),
+            hostnames: vec![hostname.to_string()],
+        });
+        
+        Ok(())
+    }
+    
+    fn remove_entry(&mut self, hostname: &str) -> Result<()> {
+        let mut updated = false;
+        
+        for entry in &mut self.entries {
+            if let Some(pos) = entry.hostnames.iter().position(|h| h == hostname) {
+                entry.hostnames.remove(pos);
+                updated = true;
+                break;
+            }
+        }
+        
+        // Remove any empty entries
+        self.entries.retain(|entry| !entry.hostnames.is_empty());
+        
+        if !updated {
+            Err(DnsEditError::ParseError(format!("Hostname {} not found", hostname)))
+        } else {
+            Ok(())
+        }
+    }
+    
+    fn update_entry(&mut self, hostname: &str, new_ip: &str) -> Result<()> {
+        // Validate IP
+        if !Self::is_valid_ip(new_ip) {
+            return Err(DnsEditError::InvalidIp(new_ip.to_string()));
+        }
+        
+        // Remove the old entry
+        self.remove_entry(hostname)?;
+        
+        // Add the new entry
+        self.add_entry(new_ip, hostname)?;
+        
+        Ok(())
+    }
+}
+
+fn init_git_repo() -> Result<()> {
+    // Create backup directory if it doesn't exist
+    fs::create_dir_all(BACKUP_DIR)
+        .map_err(|e| DnsEditError::Io(e))?;
+    
+    // Check if git repository already exists
+    let git_dir = PathBuf::from(BACKUP_DIR).join(".git");
+    if !git_dir.exists() {
+        // Initialize git repository
+        let output = ProcessCommand::new("git")
+            .args(["init"])
+            .current_dir(BACKUP_DIR)
+            .output()
+            .map_err(|e| DnsEditError::GitError(format!("Failed to initialize git repo: {}", e)))?;
+        
+        if !output.status.success() {
+            return Err(DnsEditError::GitError(String::from_utf8_lossy(&output.stderr).to_string()));
+        }
+        
+        // Configure git user for commits
+        let _ = ProcessCommand::new("git")
+            .args(["config", "user.name", "DNS Edit"])
+            .current_dir(BACKUP_DIR)
+            .output();
+            
+        let _ = ProcessCommand::new("git")
+            .args(["config", "user.email", "dns-edit@localhost"])
+            .current_dir(BACKUP_DIR)
+            .output();
+    }
+    
+    Ok(())
+}
+
+fn backup_hosts_file(message: &str) -> Result<()> {
+    // Initialize git repository
+    init_git_repo()?;
+    
+    // Copy current hosts file to backup directory
+    let hosts_content = fs::read_to_string(HOSTS_FILE)
+        .map_err(|e| DnsEditError::Io(e))?;
+    
+    let backup_path = PathBuf::from(BACKUP_DIR).join("hosts");
+    fs::write(&backup_path, hosts_content)
+        .map_err(|e| DnsEditError::Io(e))?;
+    
+    // Add to git
+    let _ = ProcessCommand::new("git")
+        .args(["add", "hosts"])
+        .current_dir(BACKUP_DIR)
+        .output()
+        .map_err(|e| DnsEditError::GitError(format!("Failed to add to git: {}", e)))?;
+    
+    // Commit changes
+    let output = ProcessCommand::new("git")
+        .args(["commit", "-m", message])
+        .current_dir(BACKUP_DIR)
+        .output()
+        .map_err(|e| DnsEditError::GitError(format!("Failed to commit: {}", e)))?;
+    
+    if !output.status.success() && !String::from_utf8_lossy(&output.stderr).contains("nothing to commit") {
+        return Err(DnsEditError::GitError(String::from_utf8_lossy(&output.stderr).to_string()));
+    }
+    
+    Ok(())
+}
+
+fn restore_from_backup(commit: Option<&str>) -> Result<()> {
+    // Initialize git repository
+    init_git_repo()?;
+    
+    // Backup current hosts file before restoring
+    backup_hosts_file("Auto-backup before restore")?;
+    
+    // Checkout specific commit or HEAD
+    let commit_ref = commit.unwrap_or("HEAD");
+    
+    let output = ProcessCommand::new("git")
+        .args(["checkout", commit_ref, "--", "hosts"])
+        .current_dir(BACKUP_DIR)
+        .output()
+        .map_err(|e| DnsEditError::GitError(format!("Failed to checkout: {}", e)))?;
+    
+    if !output.status.success() {
+        return Err(DnsEditError::GitError(String::from_utf8_lossy(&output.stderr).to_string()));
+    }
+    
+    // Copy restored file back to /etc/hosts
+    let backup_path = PathBuf::from(BACKUP_DIR).join("hosts");
+    let backup_content = fs::read_to_string(&backup_path)
+        .map_err(|e| DnsEditError::Io(e))?;
+    
+    fs::write(HOSTS_FILE, backup_content)
+        .map_err(|e| DnsEditError::Io(e))?;
+    
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    
+    match &cli.command {
+        Commands::List { filter } => {
+            let content = fs::read_to_string(HOSTS_FILE)?;
+            let dns_file = DnsFile::from_content(&content)?;
+            
+            println!("DNS Entries:");
+            for entry in dns_file.entries {
+                for hostname in entry.hostnames {
+                    if let Some(pattern) = filter {
+                        if !hostname.contains(pattern) {
+                            continue;
+                        }
+                    }
+                    println!("{} -> {}", hostname, entry.ip);
                 }
             }
         }
+        
+        Commands::Add { ip, hostname } => {
+            // Backup before modification
+            backup_hosts_file(&format!("Backup before adding {} -> {}", hostname, ip))?;
+            
+            // Read and parse hosts file
+            let content = fs::read_to_string(HOSTS_FILE)?;
+            let mut dns_file = DnsFile::from_content(&content)?;
+            
+            // Add new entry
+            dns_file.add_entry(ip, hostname)?;
+            
+            // Write back to hosts file
+            fs::write(HOSTS_FILE, dns_file.to_string())?;
+            
+            println!("Added DNS entry: {} -> {}", hostname, ip);
+        }
+        
+        Commands::Remove { hostname } => {
+            // Backup before modification
+            backup_hosts_file(&format!("Backup before removing {}", hostname))?;
+            
+            // Read and parse hosts file
+            let content = fs::read_to_string(HOSTS_FILE)?;
+            let mut dns_file = DnsFile::from_content(&content)?;
+            
+            // Remove entry
+            dns_file.remove_entry(hostname)?;
+            
+            // Write back to hosts file
+            fs::write(HOSTS_FILE, dns_file.to_string())?;
+            
+            println!("Removed DNS entry for {}", hostname);
+        }
+        
+        Commands::Update { hostname, ip } => {
+            // Backup before modification
+            backup_hosts_file(&format!("Backup before updating {} to {}", hostname, ip))?;
+            
+            // Read and parse hosts file
+            let content = fs::read_to_string(HOSTS_FILE)?;
+            let mut dns_file = DnsFile::from_content(&content)?;
+            
+            // Update entry
+            dns_file.update_entry(hostname, ip)?;
+            
+            // Write back to hosts file
+            fs::write(HOSTS_FILE, dns_file.to_string())?;
+            
+            println!("Updated DNS entry: {} -> {}", hostname, ip);
+        }
+        
+        Commands::Restore { commit } => {
+            restore_from_backup(commit.as_deref())?;
+            println!("Restored hosts file from backup{}", 
+                     commit.as_ref().map_or(String::new(), |c| format!(" (commit {})", c)));
+        }
     }
-
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&dns).expect("Failed to serialize the dns")
-    );
-
-    let mut raw_args: Vec<String> = env::args().collect::<Vec<String>>();
-    if raw_args.len() > 1 {
-        raw_args.remove(0);
-    }
-    let args = raw_args.join(" ");
-    println!("Args: {args}");
+    
+    Ok(())
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1,0 +1,145 @@
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+// These tests are designed to be run with `cargo test --test cli_test`
+
+#[test]
+fn test_cli_add_remove_update() {
+    // Create a temporary directory for our test
+    let temp_dir = tempdir().unwrap();
+    let hosts_path = temp_dir.path().join("hosts");
+    
+    // Create a test hosts file
+    let test_content = "# Test hosts file
+127.0.0.1 localhost
+";
+    fs::write(&hosts_path, test_content).unwrap();
+    
+    // Build the binary (assumes we're running this from the project root)
+    let status = Command::new("cargo")
+        .args(["build"])
+        .status()
+        .unwrap();
+    assert!(status.success());
+    
+    // Test environment variables to override constants
+    let backup_dir_path = temp_dir.path().join("dns");
+    let env_vars = [
+        ("HOSTS_FILE", hosts_path.to_str().unwrap()),
+        ("BACKUP_DIR", backup_dir_path.to_str().unwrap()),
+    ];
+    
+    // Test adding a new entry
+    let output = Command::new("./target/debug/dns_edit")
+        .args(["add", "192.168.1.10", "test.example.com"])
+        .envs(env_vars.iter().cloned())
+        .output()
+        .unwrap();
+    
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("Added DNS entry"));
+    
+    // Verify the file was updated
+    let content = fs::read_to_string(&hosts_path).unwrap();
+    assert!(content.contains("192.168.1.10 test.example.com"));
+    
+    // Test listing entries
+    let output = Command::new("./target/debug/dns_edit")
+        .args(["list"])
+        .envs(env_vars.iter().cloned())
+        .output()
+        .unwrap();
+    
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("localhost -> 127.0.0.1"));
+    assert!(stdout.contains("test.example.com -> 192.168.1.10"));
+    
+    // Test listing with filter
+    let output = Command::new("./target/debug/dns_edit")
+        .args(["list", "-f", "example"])
+        .envs(env_vars.iter().cloned())
+        .output()
+        .unwrap();
+    
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("localhost"));
+    assert!(stdout.contains("test.example.com"));
+    
+    // Test updating an entry
+    let output = Command::new("./target/debug/dns_edit")
+        .args(["update", "test.example.com", "10.10.10.10"])
+        .envs(env_vars.iter().cloned())
+        .output()
+        .unwrap();
+    
+    assert!(output.status.success());
+    
+    // Verify the file was updated
+    let content = fs::read_to_string(&hosts_path).unwrap();
+    assert!(!content.contains("192.168.1.10 test.example.com"));
+    assert!(content.contains("10.10.10.10 test.example.com"));
+    
+    // Test removing an entry
+    let output = Command::new("./target/debug/dns_edit")
+        .args(["remove", "test.example.com"])
+        .envs(env_vars.iter().cloned())
+        .output()
+        .unwrap();
+    
+    assert!(output.status.success());
+    
+    // Verify the file was updated
+    let content = fs::read_to_string(&hosts_path).unwrap();
+    assert!(!content.contains("test.example.com"));
+}
+
+#[test]
+fn test_cli_error_handling() {
+    // Create a temporary directory for our test
+    let temp_dir = tempdir().unwrap();
+    let hosts_path = temp_dir.path().join("hosts");
+    
+    // Create a test hosts file
+    let test_content = "# Test hosts file
+127.0.0.1 localhost
+";
+    fs::write(&hosts_path, test_content).unwrap();
+    
+    // Test environment variables to override constants
+    let backup_dir_path = temp_dir.path().join("dns");
+    let env_vars = [
+        ("HOSTS_FILE", hosts_path.to_str().unwrap()),
+        ("BACKUP_DIR", backup_dir_path.to_str().unwrap()),
+    ];
+    
+    // Test invalid IP - we'll just check it fails
+    let output = Command::new("./target/debug/dns_edit")
+        .args(["add", "999.999.999.999", "test.example.com"])
+        .envs(env_vars.iter().cloned())
+        .output()
+        .unwrap();
+    
+    assert!(!output.status.success());
+    
+    // Test invalid hostname - we know the program rejects it, but we can just
+    // check the exit code rather than the exact error message which might change
+    let output = Command::new("./target/debug/dns_edit")
+        .args(["add", "127.0.0.1", "invalid$.example.com"])
+        .envs(env_vars.iter().cloned())
+        .output()
+        .unwrap();
+    
+    assert!(!output.status.success()); // Just check it failed
+    
+    // Test hostname that doesn't exist
+    let output = Command::new("./target/debug/dns_edit")
+        .args(["remove", "doesnotexist.example.com"])
+        .envs(env_vars.iter().cloned())
+        .output()
+        .unwrap();
+    
+    assert!(!output.status.success());
+}


### PR DESCRIPTION
## Summary
- Complete implementation of DNS Edit tool that allows managing `/etc/hosts` entries
- Adds automatic git-based version control in `/usr/local/dns`
- Includes comprehensive test suite with unit and integration tests

## Test plan
- Run `cargo test` to verify all unit and integration tests pass
- Try commands: `cargo run -- list`, `cargo run -- add 127.0.0.1 test.local`, etc.
- Verify backups are created in `/usr/local/dns` with proper commit messages